### PR TITLE
Add parameter to skip removing the styles

### DIFF
--- a/package/index.js
+++ b/package/index.js
@@ -9,6 +9,7 @@ export const createWebComponent = ({
   h,
   createApp,
   getCurrentInstance,
+  skipRemoveStylesOnUnmount
 }) => {
   if (!rootComponent) {
     console.warn('No root component provided. Please provide a root component to create a web component.')
@@ -48,6 +49,7 @@ export const createWebComponent = ({
       createApp,
       getCurrentInstance,
       elementName,
+      skipRemoveStylesOnUnmount
     })
   )
 }

--- a/package/src/web-component-util.js
+++ b/package/src/web-component-util.js
@@ -21,6 +21,7 @@ export const defineCustomElement = ({
   createApp,
   getCurrentInstance,
   elementName,
+  skipRemoveStylesOnUnmount
 }) =>
   VueDefineCustomElement({
     styles: [cssFrameworkStyles],
@@ -47,7 +48,9 @@ export const defineCustomElement = ({
           }
         },
         unmounted() {
-          this.__style?.remove()
+          if(!skipRemoveStylesOnUnmount) {
+            this.__style?.remove()
+          }
         },
       })
 

--- a/package/types.d.ts
+++ b/package/types.d.ts
@@ -13,6 +13,7 @@ export interface CreateWebComponentOptions {
   h: (...args: any[]) => any
   getCurrentInstance: (...args: any[]) => any
   createApp: (...args: any[]) => any
+  skipRemoveStylesOnUnmount?: boolean
 }
 
 export function createWebComponent(options: CreateWebComponentOptions): void


### PR DESCRIPTION
Add an optional configuration option to skip removing the styles on each component's unmount. 
This resolves #11, where styles were removed before the transition animation was started, and created a visual artifact of unstyled components animating.