### PR TITLE
fix typescript errors when importing package

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,14 @@
     "types": "package/types.d.ts",
     "exports": {
         ".": {
-            "import": "./package/dist/vue-web-component-wrapper.es.js",
-            "require": "./package/dist/vue-web-component-wrapper.umd.js"
+            "import": {
+                "types": "./package/types.d.ts",
+                "default": "./package/dist/vue-web-component-wrapper.es.js"
+            },
+            "require": {
+                "types": "./package/types.d.ts",
+                "default": "./package/dist/vue-web-component-wrapper.umd.js"
+            }
         }
     },
     "scripts": {

--- a/package/package.json
+++ b/package/package.json
@@ -14,8 +14,14 @@
   "module": "dist/vue-web-component-wrapper.es.js",
   "exports": {
     ".": {
-      "import": "./dist/vue-web-component-wrapper.es.js",
-      "require": "./dist/vue-web-component-wrapper.umd.js"
+      "import": {
+        "types": "./types.d.ts",
+        "default": "./dist/vue-web-component-wrapper.es.js"
+      },
+      "require": {
+        "types": "./types.d.ts",
+        "default": "./dist/vue-web-component-wrapper.umd.js"
+      }
     }
   },
   "files": [


### PR DESCRIPTION
Fixes error on importing the package when using typescript

Could not find a declaration file for module 'vue-web-component-wrapper'. '....../node_modules/vue-web-component-wrapper/package/dist/vue-web-component-wrapper.es.js' implicitly has an 'any' type.
  There are types at '...../node_modules/vue-web-component-wrapper/package/types.d.ts', but this result could not be resolved when respecting package.json "exports". The 'vue-web-component-wrapper' library may need to update its package.json or typings.ts(7016)