### PR TITLE
fix: slot processing with nested elements when disableShadowDOM: true

### DIFF
--- a/package/src/api-custom-element.ts
+++ b/package/src/api-custom-element.ts
@@ -322,9 +322,9 @@ export class VueElement extends BaseClass {
       if (!this._config.shadowRoot) {
         this._slots = {};
 
-        const processChildNodes = (nodes: NodeList): (string | VNode)[] => {
+        const processChildNodes = (nodes: NodeList): (VNode | string)[] => {
           return Array.from(nodes)
-            .map((node) : string | VNode | null  => {
+            .map((node) : VNode | string | null  => {
               if (node.nodeType === Node.ELEMENT_NODE) {
                 const element = node as HTMLElement;
                 const attributes = Object.fromEntries(
@@ -340,7 +340,7 @@ export class VueElement extends BaseClass {
               }
               return null;
             })
-            .filter((node): node is string | VNode => node != null);
+            .filter((node): node is VNode | string => node != null);
         };
 
         for (const child of Array.from(this.childNodes)) {

--- a/package/src/api-custom-element.ts
+++ b/package/src/api-custom-element.ts
@@ -321,15 +321,58 @@ export class VueElement extends BaseClass {
       // replace slot
       if (!this._config.shadowRoot) {
         this._slots = {};
-        for (const child of Array.from(this.children)) {
-          const slotName = child.getAttribute('slot') || 'default';
+
+        const processChildNodes = (nodes: NodeListOf<ChildNode>): any[] => {
+          return Array.from(nodes)
+            .map((node) => {
+              if (node.nodeType === Node.ELEMENT_NODE) {
+                const element = node as HTMLElement;
+                const attributes = Object.fromEntries(
+                  Array.from(element.attributes).map((attr) => [attr.name, attr.value])
+                );
+                return h(
+                  element.tagName.toLowerCase(),
+                  attributes,
+                  processChildNodes(element.childNodes)
+                );
+              } else if (node.nodeType === Node.TEXT_NODE) {
+                return node.textContent?.trim() || null;
+              }
+              return null;
+            })
+            .filter(Boolean);
+        };
+
+        for (const child of Array.from(this.childNodes)) {
+          const slotName = child.nodeType === Node.ELEMENT_NODE
+          ? (child as HTMLElement).getAttribute('slot') || 'default'
+          : 'default';
+
           if (!this._slots[slotName]) {
             this._slots[slotName] = [];
           }
-          this._slots[slotName].push(
-            h(child.tagName.toLowerCase(), {}, child.innerHTML)
-          );
+
+          if (child.nodeType === Node.ELEMENT_NODE) {
+            const element = child as HTMLElement;
+            const attributes = Object.fromEntries(
+              Array.from(element.attributes).map((attr) => [attr.name, attr.value])
+            );
+            this._slots[slotName].push(
+              h(
+                element.tagName.toLowerCase(),
+                attributes,
+                processChildNodes(element.childNodes)
+              )
+            );
+          } else if (child.nodeType === Node.TEXT_NODE) {
+            const textContent = child.textContent?.trim();
+            if (textContent) {
+              // @ts-ignore
+              this._slots[slotName].push(textContent);
+            }
+          }
         }
+
         this.replaceChildren();
       }
 

--- a/package/src/api-custom-element.ts
+++ b/package/src/api-custom-element.ts
@@ -322,9 +322,9 @@ export class VueElement extends BaseClass {
       if (!this._config.shadowRoot) {
         this._slots = {};
 
-        const processChildNodes = (nodes: NodeListOf<ChildNode>): any[] => {
+        const processChildNodes = (nodes: NodeList): (string | VNode)[] => {
           return Array.from(nodes)
-            .map((node) => {
+            .map((node) : string | VNode | null  => {
               if (node.nodeType === Node.ELEMENT_NODE) {
                 const element = node as HTMLElement;
                 const attributes = Object.fromEntries(
@@ -340,7 +340,7 @@ export class VueElement extends BaseClass {
               }
               return null;
             })
-            .filter(Boolean);
+            .filter((node): node is string | VNode => node != null);
         };
 
         for (const child of Array.from(this.childNodes)) {


### PR DESCRIPTION
When `disableShadowDOM: true` is set, there are significant issues with slot handling in nested components. These problems arise due to the current implementation in the package.

## 1. Basic Text Not Rendered
The text `abc` does not render.

```html
<xx-component name="core-btn">abc</xx-component>
```

## 2. Inner HTML as Text Output Only
`<h1>abc</h1>` only outputs the text as-is

```html
<div slot="prev">
  <h1>abc</h1>
</div>
```

## 3. Attributes Are Lost
In this case, attributes such as `class="text-red"`  and `id="test"` are stripped because the h function returns an empty object {} for attributes.

```html
<xx-component name="core-btn">
  <div class="text-red" id="test">abc</div>
</xx-component>
```

## 4.Not support nested component like `<xx-component>` in side `<xx-component>`